### PR TITLE
Speedup normal character handling routine and align LINTAB

### DIFF
--- a/sw/vt1802.asm
+++ b/sw/vt1802.asm
@@ -178,8 +178,12 @@ E
 ;
 ; 036	-- Fix SCRDWN to erase the correct line. Fix DMA burst setting.
 ;
+; 037	-- Align LINTAB to speed up access in critical path. Rewrite the
+;	     normal (regular printable) character handling routine to speed
+;	     up termianl output.
+;
 ;--
-VEREDT	.EQU	36	; and the edit level
+VEREDT	.EQU	37	; and the edit level
 
 ; TODO list-
 ;   Drawing boxes and lines should be easier - maybe some kind of escape


### PR DESCRIPTION
Since for typical use the normal printable characters comprise most of the output, this speeds their display to increase overall speed. This gets me to 425 cps in terminal mode at 9600 baud.