### PR TITLE
Major restructuring around calls and jump tables

### DIFF
--- a/sw/vt1802.asm
+++ b/sw/vt1802.asm
@@ -198,8 +198,14 @@
 ;	     Make ISR handle multiple events per invocation to reduce latency
 ;	     and overhead when interrupts happen during interrupts.
 ;
+; 042	-- Major restructuring around the termainal main loop and subroutine
+;	     calls for the basic I/O functions, adapting a quick call scheme
+;	     for those time critical things. Changed the jump tables from
+;	     plain addresses to LBR instructions to avoid need for SEP stuff.
+;	     Other changes and restructuring to support this.
+;
 ;--
-VEREDT	.EQU	41	; and the edit level
+VEREDT	.EQU	42	; and the edit level
 ;
 ; TODO list-
 ;   Drawing boxes and lines should be easier - maybe some kind of escape

--- a/sw/vt1802.asm
+++ b/sw/vt1802.asm
@@ -1691,6 +1691,8 @@ SERPU3:	QCALL(SERPUQ)
 	IRX\ POPRL(T1)		; restore T1
 	GHI AUX\ RETURN		; and we're done
 
+	.SBTTL	GETKEY and VTPUTC Standard Call Wrapper Routines
+
 ;++
 ;   This is an SCRT wrapper around the GETKEQ quick-call subroutine so that
 ; it can be used by BASIC and the monitor through CALL(GETKEQ). This gets
@@ -1702,8 +1704,6 @@ GETKEY:	PUSHR(T1)\ PUSHR(T2)	; save two working registers
 	QCALL(GETKEQ)
 	IRX\ POPR(T2)\ POPRL(T1); restore saved registers
 	GHI AUX\ RETURN		; and we're done
-
-	.SBTTL	Output Characters to the Screen
 
 ;++
 ;   This is a wrapper around the VTPUTQ routine to save the registers that
@@ -2064,6 +2064,8 @@ SHORE2:	OUTCHR('R')		; type "Rn="
 
 ; Messages...
 BPTMSG:	.TEXT	"\r\nBREAK AT \000"
+
+	.SBTTL	Output Characters to the Screen
 
 ;++
 ;   This routine is called whenever we want to send a character to the video
@@ -4326,6 +4328,7 @@ SLUIS2:	RLDI(T1,SLUFMT)\ LDN T1	; get the current SLU format bits
 ; There's nothing more to do!
 SLUIS3:	SEX SP\ LBR ISRDON	; dismiss the interrupt and we're done
 
+	.SBTTL	Serial Port Buffer Routines
 
 ;++
 ;   This routine will extract and return the next character from the serial


### PR DESCRIPTION
This is a pretty major group of changes. Part of it is changing the critical I/O routines to a "quick call" scheme instead of SCRT (and providing wrappers for SCRT for what needs it), and then writing the terminal loop to use these quick calls. This also changes the jump table entries from plain addresses to LBR instructions. There is a fair amount of other restructuring to accommodate all this and further tweak speed. This gives me 890 characters per second with a 4 MHz processor clock. I tested BASIC including XMODEM and console as well as terminal.